### PR TITLE
Parse configuration files using ESLint

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1,12 +1,24 @@
 var EsLint = require("eslint").linter;
+var configFile = require("eslint/lib/config/config-file");
+var fs = require("fs");
+var temp = require("temp").track();
 
-function parseConfig(config) {
+function Linter(outbound) {
+  this.outbound = outbound;
+}
+
+Linter.prototype.parseConfig = function(config) {
   if (!config) {
     config = "{}";
   }
 
+  var path = temp.path("eslintrc");
+  fs.writeFileSync(path, config, "utf8", function() {});
+
   try {
-    return JSON.parse(config);
+    var configContent = configFile.load(path);
+    temp.cleanup();
+    return configContent;
   } catch (exception) {
     console.log("Invalid ESLint configuration:");
     console.log(config);
@@ -16,12 +28,11 @@ function parseConfig(config) {
   }
 }
 
-function Linter(outbound) {
-  this.outbound = outbound;
-}
-
 Linter.prototype.lint = function(payload) {
-  var errors = EsLint.verify(payload.content, parseConfig(payload.config));
+  var errors = EsLint.verify(
+    payload.content,
+    this.parseConfig(payload.config)
+  );
 
   var violations = errors.map(function(error) {
     return { line: error.line, message: error.message };

--- a/package.json
+++ b/package.json
@@ -30,10 +30,12 @@
     "eslint": "^1.6.0",
     "node-resque": "^1.1.1",
     "redis": "^2.1.0",
-    "rsvp": "^3.1.0"
+    "rsvp": "^3.1.0",
+    "temp": "^0.8.3"
   },
   "devDependencies": {
     "fakeredis": "^0.3.3",
-    "qunit": "^0.7.7"
+    "qunit": "^0.7.7",
+    "temp": "^0.8.3"
   }
 }

--- a/tests/linter-test.js
+++ b/tests/linter-test.js
@@ -2,6 +2,26 @@ var Linter = require("../lib/linter");
 
 QUnit.module("Linter");
 
+test("Parsing an ESLint config file", function() {
+  var config = "{ \"rules\": { \"semi\": 2, }, }";
+  var outbound = {
+    enqueue: function(job) {
+      return job;
+    }
+  };
+  var linter = new Linter(outbound);
+
+  deepEqual(
+      linter.parseConfig(config),
+      {
+        globals: {},
+        env: {},
+        rules: { semi: 2 },
+        ecmaFeatures: {}
+      }
+  );
+});
+
 test("ESLint linting", function() {
   var payload = {
     content: "var foo",


### PR DESCRIPTION
This changes how the parsing logic works in hound-eslint, by using how
ESLint parses its configuration files internally. Which means the users
will be less surprised using hound-eslint, since their configuration
files will work as intended.

Changes:

- Add `temp` to create a tempfile with the content of the configuration
  files. All this, since `ESLint` expects real files - which is
  something that we do not have.
- Promote `parseConfig` to live on the prototype on `Linter`.
- Add unit tests for parsing a sample ESLint configuration file, which
  has trailing commas in it. Which are invalid JSON, but a valid ESLint
  configuration file.

https://trello.com/c/mriKkZaE