### PR TITLE
Enable plugins for ESLint

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1,7 +1,13 @@
 var EsLint = require("eslint").linter;
 var configFile = require("eslint/lib/config/config-file");
+var rules = require("eslint/lib/rules");
+var util = require("eslint/lib/util");
 var fs = require("fs");
 var temp = require("temp").track();
+
+var whitelist = [
+  "react"
+];
 
 function Linter(outbound) {
   this.outbound = outbound;
@@ -17,6 +23,7 @@ Linter.prototype.parseConfig = function(config) {
 
   try {
     var configContent = configFile.load(path);
+    this.loadPlugins(configContent.plugins);
     temp.cleanup();
     return configContent;
   } catch (exception) {
@@ -26,6 +33,35 @@ Linter.prototype.parseConfig = function(config) {
 
     return {};
   }
+}
+
+Linter.prototype.requirePlugin = function(pluginName) {
+  var pluginNamespace = util.getNamespace(pluginName),
+      pluginNameWithoutNamespace = util.removeNameSpace(pluginName),
+      pluginNameWithoutPrefix = util.removePluginPrefix(
+        pluginNameWithoutNamespace
+      ),
+      plugin;
+
+  if (whitelist.indexOf(pluginNameWithoutPrefix) > -1) {
+    plugin = require(
+      pluginNamespace +
+      util.PLUGIN_NAME_PREFIX +
+      pluginNameWithoutPrefix
+    );
+    // if this plugin has rules, import them
+    if (plugin.rules) {
+      rules.import(plugin.rules, pluginNameWithoutPrefix);
+    }
+  }
+}
+
+// Stolen, and modified, from:
+// https://github.com/eslint/eslint/blob/72a325ca31be20f7a9695556cb5883cd4e9cce14/lib/cli-engine.js#L110-L136
+Linter.prototype.loadPlugins = function(pluginNames) {
+  if (!pluginNames) { return };
+
+  pluginNames.forEach(this.requirePlugin);
 }
 
 Linter.prototype.lint = function(payload) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/thoughtbot/hound-eslint#readme",
   "dependencies": {
     "eslint": "^1.6.0",
+    "eslint-plugin-react": "^3.14.0",
     "node-resque": "^1.1.1",
     "redis": "^2.1.0",
     "rsvp": "^3.1.0",


### PR DESCRIPTION
This enables ESLint plugins to be installed and used, simply by adding
them to the `package.json` file.

Changes:

- Add `loadPlugins` from [ESLint][1].
  Since `loadPlugins` is not a part of the public API of ESLint, I
  inlined the function with a note listing its origin.
- Add support for React by adding `eslint-plugin-react`.

[1]: https://github.com/eslint/eslint/blob/72a325ca31be20f7a9695556cb5883cd4e9cce14/lib/cli-engine.js#L110-L136

https://trello.com/c/HP7aAOzg