### PR TITLE
Always cleanup temporary files

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -24,7 +24,7 @@ Linter.prototype.parseConfig = function(config) {
   try {
     var configContent = configFile.load(path);
     this.loadPlugins(configContent.plugins);
-    temp.cleanup();
+
     return configContent;
   } catch (exception) {
     console.log("Invalid ESLint configuration:");
@@ -32,6 +32,8 @@ Linter.prototype.parseConfig = function(config) {
     console.log(exception);
 
     return {};
+  } finally {
+    temp.cleanup();
   }
 }
 


### PR DESCRIPTION
Even if there was an issue with parsing the configuration file, we
should remove any tempfiles that were created in the process to avoid
memory leaks.