### PR TITLE
Report invalid ESLint configuration files

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,70 @@
+var configFile = require("eslint/lib/config/config-file");
+var fs = require("fs");
+var queue = require("./queue");
+var rules = require("eslint/lib/rules");
+var temp = require("temp").track();
+var util = require("eslint/lib/util");
+
+var whitelist = [
+  "react",
+];
+
+function Config(rawConfig) {
+  this.rawConfig = rawConfig;
+};
+
+Config.prototype.parse = function() {
+  var config = this.rawConfig || "{}";
+  var path = temp.path("eslintrc");
+  fs.writeFileSync(path, config, "utf8", function() {});
+
+  try {
+    var configContent = configFile.load(path);
+    this.loadPlugins(configContent.plugins);
+
+    return configContent;
+  } finally {
+    temp.cleanup();
+  }
+};
+
+Config.prototype.isValid = function() {
+  try {
+    this.parse();
+    return true;
+  } catch (exception) {
+    return false;
+  }
+};
+
+// Stolen, and modified, from:
+// https://github.com/eslint/eslint/blob/72a325ca31be20f7a9695556cb5883cd4e9cce14/lib/cli-engine.js#L110-L136
+Config.prototype.requirePlugin = function(pluginName) {
+  var pluginNamespace = util.getNamespace(pluginName);
+  var pluginNameWithoutNamespace = util.removeNameSpace(pluginName);
+  var pluginNameWithoutPrefix = util.removePluginPrefix(
+    pluginNameWithoutNamespace
+  );
+
+  if (whitelist.indexOf(pluginNameWithoutPrefix) > -1) {
+    var plugin = require(
+      pluginNamespace +
+      util.PLUGIN_NAME_PREFIX +
+      pluginNameWithoutPrefix
+    );
+    // if this plugin has rules, import them
+    if (plugin.rules) {
+      rules.import(plugin.rules, pluginNameWithoutPrefix);
+    }
+  }
+};
+
+Config.prototype.loadPlugins = function(pluginNames) {
+  if (pluginNames) {
+    pluginNames.forEach(this.requirePlugin);
+  } else {
+    return;
+  }
+};
+
+module.exports = Config;

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1,88 +1,38 @@
 var EsLint = require("eslint").linter;
-var configFile = require("eslint/lib/config/config-file");
-var rules = require("eslint/lib/rules");
-var util = require("eslint/lib/util");
-var fs = require("fs");
-var temp = require("temp").track();
+var Config = require("./config");
+var ReportInvalidConfig = require("./report-invalid-config");
 
-var whitelist = [
-  "react"
-];
-
-function Linter(outbound) {
-  this.outbound = outbound;
-}
-
-Linter.prototype.parseConfig = function(config) {
-  if (!config) {
-    config = "{}";
-  }
-
-  var path = temp.path("eslintrc");
-  fs.writeFileSync(path, config, "utf8", function() {});
-
-  try {
-    var configContent = configFile.load(path);
-    this.loadPlugins(configContent.plugins);
-
-    return configContent;
-  } catch (exception) {
-    console.log("Invalid ESLint configuration:");
-    console.log(config);
-    console.log(exception);
-
-    return {};
-  } finally {
-    temp.cleanup();
-  }
-}
-
-Linter.prototype.requirePlugin = function(pluginName) {
-  var pluginNamespace = util.getNamespace(pluginName),
-      pluginNameWithoutNamespace = util.removeNameSpace(pluginName),
-      pluginNameWithoutPrefix = util.removePluginPrefix(
-        pluginNameWithoutNamespace
-      ),
-      plugin;
-
-  if (whitelist.indexOf(pluginNameWithoutPrefix) > -1) {
-    plugin = require(
-      pluginNamespace +
-      util.PLUGIN_NAME_PREFIX +
-      pluginNameWithoutPrefix
-    );
-    // if this plugin has rules, import them
-    if (plugin.rules) {
-      rules.import(plugin.rules, pluginNameWithoutPrefix);
-    }
-  }
-}
-
-// Stolen, and modified, from:
-// https://github.com/eslint/eslint/blob/72a325ca31be20f7a9695556cb5883cd4e9cce14/lib/cli-engine.js#L110-L136
-Linter.prototype.loadPlugins = function(pluginNames) {
-  if (!pluginNames) { return };
-
-  pluginNames.forEach(this.requirePlugin);
+function Linter(resultQueues) {
+  this.completedFileReviewQueue = resultQueues.complete;
+  this.reportInvalidConfigQueue = resultQueues.invalid;
 }
 
 Linter.prototype.lint = function(payload) {
-  var errors = EsLint.verify(
-    payload.content,
-    this.parseConfig(payload.config)
-  );
+  var config = new Config(payload.config);
 
-  var violations = errors.map(function(error) {
-    return { line: error.line, message: error.message };
-  });
+  if (config.isValid()) {
+    var errors = EsLint.verify(
+      payload.content,
+      config.parse()
+    );
 
-  return this.outbound.enqueue({
-    violations: violations,
-    filename: payload.filename,
-    commit_sha: payload.commit_sha,
-    pull_request_number: payload.pull_request_number,
-    patch: payload.patch,
-  });
+    var violations = errors.map(function(error) {
+      return { line: error.line, message: error.message };
+    });
+
+    return this.completedFileReviewQueue.enqueue({
+      violations: violations,
+      filename: payload.filename,
+      commit_sha: payload.commit_sha,
+      pull_request_number: payload.pull_request_number,
+      patch: payload.patch,
+    });
+  } else {
+    var reportInvalidConfig = new ReportInvalidConfig(
+      this.reportInvalidConfigQueue
+    );
+    return reportInvalidConfig.run(payload);
+  }
 };
 
 module.exports = Linter;

--- a/lib/report-invalid-config.js
+++ b/lib/report-invalid-config.js
@@ -1,0 +1,13 @@
+function ReportInvalidConfig(queue) {
+  this.queue = queue;
+};
+
+ReportInvalidConfig.prototype.run = function(payload) {
+  return this.queue.enqueue({
+    pull_request_number: payload.pull_request_number,
+    commit_sha: payload.commit_sha,
+    linter_name: "eslint",
+  });
+};
+
+module.exports = ReportInvalidConfig;

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   },
   "devDependencies": {
     "fakeredis": "^0.3.3",
-    "qunit": "^0.7.7",
-    "temp": "^0.8.3"
+    "qunit": "^0.7.7"
   }
 }

--- a/tests/config-test.js
+++ b/tests/config-test.js
@@ -1,0 +1,35 @@
+var Config = require("../lib/config");
+
+QUnit.module("Config");
+
+test("Parsing an ESLint config file", function() {
+  var config = new Config("{ \"rules\": { \"semi\": 2, }, }");
+
+  deepEqual(
+    config.parse(),
+    {
+      globals: {},
+      env: {},
+      rules: { semi: 2 },
+      ecmaFeatures: {},
+    }
+  );
+});
+
+test("Determining a valid configuration file", function() {
+  var config = new Config("{ \"rules\": { \"semi\": 2, }, }");
+
+  equal(
+    config.isValid(),
+    true
+  );
+});
+
+test("Determining an invalid configuration file", function() {
+  var config = new Config("---\nyaml: is good\ntrue/false/syntax/error");
+
+  equal(
+    config.isValid(),
+    false
+  );
+});

--- a/tests/integration-test.js
+++ b/tests/integration-test.js
@@ -16,7 +16,10 @@ asyncTest("Linter communicates over resque", function() {
     redis: redis,
     queueName: "high",
   });
-  var linter = new Linter(outbound);
+  var linter = new Linter({
+    complete: outbound,
+    invalid: outbound,
+  });
 
   var inboundJob = {
     content: "var foo",

--- a/tests/report-invalid-config-test.js
+++ b/tests/report-invalid-config-test.js
@@ -1,0 +1,38 @@
+var ReportInvalidConfig = require("../lib/report-invalid-config");
+
+QUnit.module("Reporting");
+
+test("Reporting an invalid configuration file", function() {
+  var reportInvalidConfigQueue = {
+    enqueue: function(job) {
+      return job;
+    },
+  };
+  var payload = {
+    content: "var foo",
+    config: "{ \"rules\": { \"semi\": 2 } }",
+    filename: "filename",
+    commit_sha: "commit_sha",
+    pull_request_number: "pull_request_number",
+    patch: "patch",
+  };
+  var reportInvalidConfig = new ReportInvalidConfig(reportInvalidConfigQueue);
+
+  var job = reportInvalidConfig.run(payload);
+
+  equal(
+    job.pull_request_number,
+    payload.pull_request_number,
+    "passes through pull_request_number"
+  );
+  equal(
+    job.commit_sha,
+    payload.commit_sha,
+    "passes through commit_sha"
+  );
+  equal(
+    job.linter_name,
+    "eslint",
+    "passes through linter_name"
+  );
+});


### PR DESCRIPTION
When an invalid configuration file is parsed, it should be marked as
invalid to let the end user know.

This is done by enqueuing the `ReportInvalidConfigJob` in Hound proper,
which will update the build status to mark the configuration file as
invalid.

Changes:

- Extract `Config` out of `Linter`.
- Remove `temp` as a development dependency.

https://trello.com/c/42U5K0Bs