### PR TITLE
Enable JSCS linting

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,5 @@
 java_script:
   config_file: .jshintrc
+jscs:
+  enabled: true
+  config_file: https://raw.githubusercontent.com/thoughtbot/guides/master/style/javascript/.jscsrc


### PR DESCRIPTION
The current Hound configuration enables JSHint, which lints for
JavaScript antipatterns and worst practices.

JSCS is more concerned with style guide violations.